### PR TITLE
Avoid creation of mu-plugin file

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -45,7 +45,7 @@ function on_plugins_loaded() {
 }
 
 /**
- * Load miu-plugins.
+ * Load mu-plugins.
  *
  * @return void
  */


### PR DESCRIPTION
Duplicate the functionality required by Patchstack's mu-plugin file, normally created as part of initialisation.

Define a constant to prevent the mu-plugins file from being created.
Only activate if the option it not set.

Split the activation and mu-plugin functionality into two separate hooks. So it can be initalized for each sub site.

Fixes https://github.com/humanmade/altis-advanced-security/issues/6


---

## For Altis Team Use

### Completion Checklist

Is this ticket done? See
[the Play Book Definition of Done](https://playbook.hmn.md/play/product/definition-of-done-2/)

- [ ] Has the acceptance criteria been met?
- ~[ ] Is the documentation updated (including README)?~
- ~[ ] Do any code/documentation changes meet project standards?~
- ~[ ] Are automatic tests in place to verify the fix or new functionality?~
  - ~[ ] Or are manual tests documented (at least on this ticket)?~
- ~[ ] Are any Playbook/Handbook pages updated?~
- ~[ ] Has a new module release (patch/minor) been created/scheduled?~
- ~[ ] Have the appropriate `backport` labels been added to the PR?~
- ~[ ] Is there a roll-out (and roll-back) plan if required?~
