### PR TITLE
Fix invalid package version

### DIFF
--- a/.github/workflows/module-auto-tagging.yml
+++ b/.github/workflows/module-auto-tagging.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4.3.1
+      - uses: actions/setup-node@v4
       - run: npm install semver
       - uses: actions/github-script@v7
         with:


### PR DESCRIPTION
This change fixes the invalid package version causing a failure when this workflow tries to run.
https://github.com/humanmade/altis-advanced-security/actions/runs/16778327269/job/47509887263
