### PR TITLE
Remove dashboard pages.

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -19,6 +19,8 @@ function bootstrap() {
 	define( 'PS_DISABLE_MU', true );
 	add_action( 'plugins_loaded', __NAMESPACE__ . '\\on_plugins_loaded', 1 );
 	add_action( 'mu_plugins_loaded', __NAMESPACE__ . '\\on_mu_plugins_loaded', 1 );
+	add_action( 'admin_menu', __NAMESPACE__ . '\\remove_options_page', 99 );
+	add_action( 'network_admin_menu', __NAMESPACE__ . '\\remove_network_page', 99 );
 }
 
 /**
@@ -90,4 +92,22 @@ function on_mu_plugins_loaded() {
 			define( 'PS_FW_MU_RAN', true );
 		}
 	}
+}
+
+/**
+ * Remove the options page from the Settings menu.
+ *
+ * @return void
+ */
+function remove_options_page() {
+	remove_submenu_page( 'options-general.php', 'patchstack' );
+}
+
+/**
+ * Remove the network admin menu.
+ *
+ * @return void
+ */
+function remove_network_page() {
+	remove_menu_page( 'patchstack-multisite' );
 }


### PR DESCRIPTION
This change removed the Dashboard Settings > Security page and the Network Admin > Patchstack pages.

Neither page is needed for operation on the Altis stack.

Before this PR main site dashboard

<img width="800" height="1052" alt="CleanShot 2025-08-14 at 16 29 21" src="https://github.com/user-attachments/assets/14e775ac-9f78-4503-b267-ce84a0451cc8" />

Before this PR Network Admin Dashboard

<img width="800" height="1052" alt="CleanShot 2025-08-14 at 16 29 43" src="https://github.com/user-attachments/assets/f8f980c6-d237-446f-b1ff-f5d25dc4fde0" />

After the PR main site dashboard

<img width="800" height="1052" alt="CleanShot 2025-08-14 at 16 30 10" src="https://github.com/user-attachments/assets/2fc09715-5d02-4f1f-8f53-2696f818fdde" />


After the PR Network Admin Dashboard

<img width="800" height="1052" alt="CleanShot 2025-08-14 at 16 29 56" src="https://github.com/user-attachments/assets/088e072f-bc97-443c-a2ba-fa77ca122aeb" />
