### PR TITLE
Update Dependabot for v25 release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,12 +53,3 @@ updates:
   - dependency-type: "direct"
   versioning-strategy: "increase"
   target-branch: v21-branch
-- package-ecosystem: composer
-  directory: "/"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 10
-  allow:
-  - dependency-type: "direct"
-  versioning-strategy: "increase"
-  target-branch: v20-branch

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,15 @@ updates:
   allow:
   - dependency-type: "direct"
   versioning-strategy: "increase"
+  target-branch: v25-branch
+- package-ecosystem: composer
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10
+  allow:
+  - dependency-type: "direct"
+  versioning-strategy: "increase"
   target-branch: v24-branch
 - package-ecosystem: composer
   directory: "/"


### PR DESCRIPTION
This PR updates Dependabot configuration to add the v25 branch.

- Addresses: https://github.com/humanmade/product-dev/issues/1876